### PR TITLE
Add the ability to manually edit and add redhen donation records.

### DIFF
--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1282,13 +1282,8 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
     'type' => $donation_type,
     'author_uid' => $GLOBALS['user']->uid,
   ));
-  // Put the donation information into a fieldset.
-  $form['redhen_donation'] = array(
-    '#type' => 'fieldset',
-    '#title' => 'Donation Information',
-  );
   // Add the donation information edit form.
-  $form['redhen_donation'] += redhen_donation_edit_form($form, $form_state, $donation);
+  $form += redhen_donation_edit_form($form, $form_state, $donation);
 
   // TO REFACTOR: Nearly the same logic as in redhen_donation_form().
   module_load_include('inc', 'redhen_contact', 'includes/redhen_contact.forms');
@@ -1301,7 +1296,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
     '#tree' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Contact Information'),
-    '#weight' => -5,
+    '#weight' => -10,
   );
   // Add all the non-# fields from the redhen contact form.
   $contact_form = redhen_contact_contact_form(array(), $form_state, $contact_object);
@@ -1310,9 +1305,6 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
       $form['redhen_contact'][$key] = $contact_form[$key];
     }
   }
-  // Move the form actions from the donation form fieldgroup.
-  $form['actions'] = $form['redhen_donation']['actions'];
-  unset($form['redhen_donation']['actions']);
 
   return $form;
 }

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1268,6 +1268,56 @@ function redhen_donation_fieldmap_options($entity_type, $entity_bundle = NULL, $
   return $options;
 }
 
+
+/**
+ * Form callback: Create a new donation record outside of the checkout process
+ */
+function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
+
+  // TO REFACTOR: Same logic as redhen_donation_donate_page().
+  list($entity_id) = entity_extract_ids($entity_type, $entity);
+  $donation_type = redhen_donation_get_entity_donation_type($entity_type, $entity);
+  $donation = entity_get_controller('redhen_donation')->create(array(
+    'entity_type' => $entity_type,
+    'entity_id' => $entity_id,
+    'type' => $donation_type,
+    'author_uid' => $GLOBALS['user']->uid,
+  ));
+
+  // TO REFACTOR: Nearly the same logic as in redhen_donation_form() to add the contact elements.
+  module_load_include('inc', 'redhen_contact', 'includes/redhen_contact.forms');
+  $donation_type = redhen_donation_type_load($donation->bundle());
+  $contact_settings = $donation_type->settings['contact_settings'];
+  $contact_object = redhen_contact_create(array('type' => $contact_settings['contact_type']));
+  $contact_wrapper = entity_metadata_wrapper('redhen_contact', $contact_object);
+  $form['redhen_contact'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Contact Information'),
+    'form' => redhen_contact_contact_form(array(), $form_state, $contact_object),
+  );
+  unset($form['redhen_contact']['form']['actions']);
+
+  // Add the donation fields in the same way as when editing an existing donation
+  return redhen_donation_edit_form($form, $form_state, $donation);
+}
+
+/**
+ * Validation callback for redhen_donation_add_form().
+ */
+function redhen_donation_add_form_validate($form, &$form_state) {
+  // Allow the edit form validate the fields that it added
+  redhen_donation_edit_form_validate($form, $form_state);
+}
+
+/**
+ * Submit callback for redhen_donation_add_form().
+ */
+function redhen_donation_add_form_submit($form, &$form_state) {
+  // Allow the edit form process the field it added
+  redhen_donation_edit_form_submit($form, $form_state);
+}
+
+
 /**
  * Form callback: edit the field for a donation.
  *

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1326,12 +1326,12 @@ function redhen_donation_add_form_submit($form, &$form_state) {
   $contact->author_uid = $GLOBALS['user']->uid;
   $contact->first_name = $form_state['values']['first_name'];
   $contact->middle_name = $form_state['values']['middle_name'];
-  $contact->last_name = $options_element_form_field_ui_field_settings_form_altere['values']['last_name'];
+  $contact->last_name = $form_state['values']['last_name'];
   field_attach_submit('redhen_contact', $contact, $form, $form_state);
-  $ret = $contact->upsert();
+  $contact->upsert();
   $form_state['donation']->contact_id = $form_state['redhen_contact']->contact_id;
 
-  // Allow the edit form process the fields it added.
+  // Allow the edit form to process the fields it added.
   redhen_donation_edit_form_submit($form, $form_state);
 
   // Redirect back to the donation list after the donation is added.

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1296,6 +1296,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   $donation_type = redhen_donation_type_load($donation->bundle());
   $contact_settings = $donation_type->settings['contact_settings'];
   $contact_object = redhen_contact_create(array('type' => $contact_settings['contact_type']));
+
   $contact_wrapper = entity_metadata_wrapper('redhen_contact', $contact_object);
   $form['redhen_contact'] = array(
     '#tree' => TRUE,
@@ -1303,7 +1304,6 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
     '#title' => t('Contact Information'),
     '#weight' => -5,
   );
-
   // Add all the non-# fields from the redhen contact form.
   $contact_form = redhen_contact_contact_form(array(), $form_state, $contact_object);
   foreach ($contact_form as $key => $element) {
@@ -1330,6 +1330,17 @@ function redhen_donation_add_form_validate($form, &$form_state) {
  * Submit callback for redhen_donation_add_form().
  */
 function redhen_donation_add_form_submit($form, &$form_state) {
+
+  // Upsert the redhen contact and include its id in the donation object.
+  $contact = $form_state['redhen_contact'];
+  $contact->author_uid = $GLOBALS['user']->uid;
+  $contact->first_name = $form_state['values']['redhen_contact']['name']['first_name'];
+  $contact->middle_name = $form_state['values']['redhen_contact']['name']['middle_name'];
+  $contact->last_name = $form_state['values']['redhen_contact']['name']['last_name'];
+  field_attach_submit('redhen_contact', $contact, $form['redhen_contact'], $form_state);
+  $ret = $contact->upsert();
+  $form_state['donation']->contact_id = $form_state['redhen_contact']->contact_id;
+
   // Allow the edit form process the field it added
   redhen_donation_edit_form_submit($form, $form_state);
 }

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1284,7 +1284,6 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   $contact_settings = $donation_type->settings['contact_settings'];
   $contact_object = redhen_contact_create(array('type' => $contact_settings['contact_type']));
 
-  $contact_wrapper = entity_metadata_wrapper('redhen_contact', $contact_object);
   $form['redhen_contact'] = array(
     '#type' => 'fieldset',
     '#title' => t('Contact Information'),

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1326,7 +1326,7 @@ function redhen_donation_add_form_submit($form, &$form_state) {
   $contact->author_uid = $GLOBALS['user']->uid;
   $contact->first_name = $form_state['values']['first_name'];
   $contact->middle_name = $form_state['values']['middle_name'];
-  $contact->last_name = $form_state['values']['last_name'];
+  $contact->last_name = $options_element_form_field_ui_field_settings_form_altere['values']['last_name'];
   field_attach_submit('redhen_contact', $contact, $form, $form_state);
   $ret = $contact->upsert();
   $form_state['donation']->contact_id = $form_state['redhen_contact']->contact_id;
@@ -1360,14 +1360,14 @@ function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation
     '#title' => t('Amount Pledged'),
     '#size' => 10,
     '#required' => TRUE,
-    '#default_value' => $donation->pledged,
+    '#default_value' => number_format($donation->pledged / 100, 2),
   );
   $form['received'] = array(
     '#type' => 'textfield',
     '#title' => t('Amount Received'),
     '#size' => 10,
     '#required' => TRUE,
-    '#default_value' => $donation->received,
+    '#default_value' => number_format($donation->received / 100, 2),
   );
 
   // Attach the field api fields for the entity.
@@ -1389,10 +1389,10 @@ function redhen_donation_edit_form_validate($form, &$form_state) {
   $donation = $form_state['donation'];
 
   if (!is_numeric($form_state['values']['pledged'])) {
-    form_set_error('pledged', t('Amount pledged must be a number with no currency symbols or commas.'));
+    form_set_error('pledged', t('Amount pledged must be a decimal number with no currency symbols or commas.'));
   }
   if (!is_numeric($form_state['values']['received'])) {
-    form_set_error('received', t('Amount received must be a number with no currency symbols or commas.'));
+    form_set_error('received', t('Amount received must be a decimal number with no currency symbols or commas.'));
   }
   // Notify field widgets to validate their data.
   field_attach_form_validate('redhen_donation', $donation, $form, $form_state);
@@ -1404,8 +1404,9 @@ function redhen_donation_edit_form_validate($form, &$form_state) {
 function redhen_donation_edit_form_submit($form, &$form_state) {
   $donation = $form_state['donation'];
 
-  $donation->pledged = $form_state['values']['pledged'];
-  $donation->received = $form_state['values']['received'];
+  // Multiply the donation amount by 100, since it seems that we are storing the value in cents
+  $donation->pledged = $form_state['values']['pledged'] * 100;
+  $donation->received = $form_state['values']['received'] * 100;
 
   // Notify field widgets.
   field_attach_submit('redhen_donation', $donation, $form, $form_state);

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1278,7 +1278,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   // Add the donation information edit form.
   $form += redhen_donation_edit_form($form, $form_state, $donation);
 
-  // TO REFACTOR: Nearly the same logic as in redhen_donation_form().
+  // @TODO: Nearly the same logic as in redhen_donation_form().
   module_load_include('inc', 'redhen_contact', 'includes/redhen_contact.forms');
   $donation_type = redhen_donation_type_load($donation->bundle());
   $contact_settings = $donation_type->settings['contact_settings'];

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1291,14 +1291,22 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   $contact_object = redhen_contact_create(array('type' => $contact_settings['contact_type']));
   $contact_wrapper = entity_metadata_wrapper('redhen_contact', $contact_object);
   $form['redhen_contact'] = array(
+    '#tree' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Contact Information'),
-    'form' => redhen_contact_contact_form(array(), $form_state, $contact_object),
   );
-  unset($form['redhen_contact']['form']['actions']);
 
-  // Add the donation fields in the same way as when editing an existing donation
-  return redhen_donation_edit_form($form, $form_state, $donation);
+  // Add all the non-# fields from the redhen contact form.
+  $contact_form = redhen_contact_contact_form(array(), $form_state, $contact_object);
+  foreach ($contact_form as $key => $element) {
+    if (substr($key, 0, 1) != '#' && $key != 'actions') {
+      $form['redhen_contact'][$key] = $contact_form[$key];
+    }
+  }
+
+  // Add the donation fields in the same way as when editing existing donations.
+  $form = redhen_donation_edit_form($form, $form_state, $donation);
+  return $form;
 }
 
 /**

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1283,6 +1283,13 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
     'type' => $donation_type,
     'author_uid' => $GLOBALS['user']->uid,
   ));
+  // Put the donation information into a fieldset.
+  $form['redhen_donation'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Donation Information',
+  );
+  // Add the donation information edit form.
+  $form['redhen_donation'] += redhen_donation_edit_form($form, $form_state, $donation);
 
   // TO REFACTOR: Nearly the same logic as in redhen_donation_form() to add the contact elements.
   module_load_include('inc', 'redhen_contact', 'includes/redhen_contact.forms');
@@ -1294,6 +1301,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
     '#tree' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Contact Information'),
+    '#weight' => -5,
   );
 
   // Add all the non-# fields from the redhen contact form.
@@ -1303,9 +1311,10 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
       $form['redhen_contact'][$key] = $contact_form[$key];
     }
   }
+  // get the form actions from the donation form
+  $form['actions'] = $form['redhen_donation']['actions'];
+  unset($form['redhen_donation']['actions']);
 
-  // Add the donation fields in the same way as when editing existing donations.
-  $form = redhen_donation_edit_form($form, $form_state, $donation);
   return $form;
 }
 

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1310,7 +1310,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
       $form['redhen_contact'][$key] = $contact_form[$key];
     }
   }
-  // Get the form actions from the donation form.
+  // Move the form actions from the donation form fieldgroup.
   $form['actions'] = $form['redhen_donation']['actions'];
   unset($form['redhen_donation']['actions']);
 
@@ -1346,7 +1346,6 @@ function redhen_donation_add_form_submit($form, &$form_state) {
   // Redirect back to the donation list after the donation is added.
   $form_state['redirect'] = str_replace("donations/add", "donations", current_path());
 }
-
 
 /**
  * Form callback: edit the field for a donation.

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1268,9 +1268,8 @@ function redhen_donation_fieldmap_options($entity_type, $entity_bundle = NULL, $
   return $options;
 }
 
-
 /**
- * Form callback: Create a new donation record outside of the checkout process
+ * Form callback: Create a new donation record outside of the checkout process.
  */
 function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
 
@@ -1291,7 +1290,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   // Add the donation information edit form.
   $form['redhen_donation'] += redhen_donation_edit_form($form, $form_state, $donation);
 
-  // TO REFACTOR: Nearly the same logic as in redhen_donation_form() to add the contact elements.
+  // TO REFACTOR: Nearly the same logic as in redhen_donation_form().
   module_load_include('inc', 'redhen_contact', 'includes/redhen_contact.forms');
   $donation_type = redhen_donation_type_load($donation->bundle());
   $contact_settings = $donation_type->settings['contact_settings'];
@@ -1311,7 +1310,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
       $form['redhen_contact'][$key] = $contact_form[$key];
     }
   }
-  // get the form actions from the donation form
+  // Get the form actions from the donation form.
   $form['actions'] = $form['redhen_donation']['actions'];
   unset($form['redhen_donation']['actions']);
 
@@ -1322,7 +1321,7 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
  * Validation callback for redhen_donation_add_form().
  */
 function redhen_donation_add_form_validate($form, &$form_state) {
-  // Allow the edit form validate the fields that it added
+  // Allow the edit form validate the fields that it added.
   redhen_donation_edit_form_validate($form, $form_state);
 }
 
@@ -1341,8 +1340,11 @@ function redhen_donation_add_form_submit($form, &$form_state) {
   $ret = $contact->upsert();
   $form_state['donation']->contact_id = $form_state['redhen_contact']->contact_id;
 
-  // Allow the edit form process the field it added
+  // Allow the edit form process the fields it added.
   redhen_donation_edit_form_submit($form, $form_state);
+
+  // Redirect back to the donation list after the donation is added.
+  $form_state['redirect'] = str_replace("donations/add", "donations", current_path());
 }
 
 
@@ -1354,19 +1356,19 @@ function redhen_donation_add_form_submit($form, &$form_state) {
  * @param array $form_state
  *   Form state array.
  * @param RedhenDonation $donation
- *   The donation object to edit
+ *   The donation object to edit.
  *
  * @return mixed
  *   Donation form array.
  */
 function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation) {
-  // Save a reference to the donation
+  // Save a copy of the donation object.
   $form_state['donation'] = $donation;
 
-  // Attach the field api fields for the entity
+  // Attach the field api fields for the entity.
   field_attach_form('redhen_donation', $donation, $form, $form_state);
 
-  // Add the action buttons to the bottom of the form
+  // Add the action buttons to the bottom of the form.
   $form['actions']['#weight'] = 100;
   $form['actions']['submit'] = array(
     '#type' => 'submit',
@@ -1394,7 +1396,7 @@ function redhen_donation_edit_form_submit($form, &$form_state) {
   // Notify field widgets.
   field_attach_submit('redhen_donation', $donation, $form, $form_state);
 
-  if(redhen_donation_save($donation)) {
+  if (redhen_donation_save($donation)) {
     drupal_set_message("The donation details has been saved.");
   }
 }

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1363,12 +1363,12 @@ function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation
     '#required' => TRUE,
     '#default_value' => $donation->pledged,
   );
-  $form['recieved'] = array(
+  $form['received'] = array(
     '#type' => 'textfield',
-    '#title' => t('Amount Recieved'),
+    '#title' => t('Amount Received'),
     '#size' => 10,
     '#required' => TRUE,
-    '#default_value' => $donation->pledged,
+    '#default_value' => $donation->received,
   );
 
   // Attach the field api fields for the entity.
@@ -1392,8 +1392,8 @@ function redhen_donation_edit_form_validate($form, &$form_state) {
   if (!is_numeric($form_state['values']['pledged'])) {
     form_set_error('pledged', t('Amount pledged must be a number with no currency symbols or commas.'));
   }
-  if (!is_numeric($form_state['values']['recieved'])) {
-    form_set_error('recieved', t('Amount recieved must be a number with no currency symbols or commas.'));
+  if (!is_numeric($form_state['values']['received'])) {
+    form_set_error('received', t('Amount received must be a number with no currency symbols or commas.'));
   }
   // Notify field widgets to validate their data.
   field_attach_form_validate('redhen_donation', $donation, $form, $form_state);
@@ -1406,7 +1406,7 @@ function redhen_donation_edit_form_submit($form, &$form_state) {
   $donation = $form_state['donation'];
 
   $donation->pledged = $form_state['values']['pledged'];
-  $donation->recieved = $form_state['values']['recieved'];
+  $donation->received = $form_state['values']['received'];
 
   // Notify field widgets.
   field_attach_submit('redhen_donation', $donation, $form, $form_state);

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1267,3 +1267,56 @@ function redhen_donation_fieldmap_options($entity_type, $entity_bundle = NULL, $
   }
   return $options;
 }
+
+/**
+ * Form callback: edit the field for a donation.
+ *
+ * @param array $form
+ *   Form array.
+ * @param array $form_state
+ *   Form state array.
+ * @param RedhenDonation $donation
+ *   The donation object to edit
+ *
+ * @return mixed
+ *   Donation form array.
+ */
+function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation) {
+  // Save a reference to the donation
+  $form_state['donation'] = $donation;
+
+  // Attach the field api fields for the entity
+  field_attach_form('redhen_donation', $donation, $form, $form_state);
+
+  // Add the action buttons to the bottom of the form
+  $form['actions']['#weight'] = 100;
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save donation'),
+  );
+  return $form;
+}
+
+/**
+ * Validation callback for redhen_donation_edit_form().
+ */
+function redhen_donation_edit_form_validate($form, &$form_state) {
+  $donation = $form_state['donation'];
+
+  // Notify field widgets to validate their data.
+  field_attach_form_validate('redhen_donation', $donation, $form, $form_state);
+}
+
+/**
+ * Submit callback for redhen_donation_edit_form().
+ */
+function redhen_donation_edit_form_submit($form, &$form_state) {
+  $donation = $form_state['donation'];
+
+  // Notify field widgets.
+  field_attach_submit('redhen_donation', $donation, $form, $form_state);
+
+  if(redhen_donation_save($donation)) {
+    drupal_set_message("The donation details has been saved.");
+  }
+}

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1365,6 +1365,21 @@ function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation
   // Save a copy of the donation object.
   $form_state['donation'] = $donation;
 
+  $form['pledged'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Amount Pledged'),
+    '#size' => 10,
+    '#required' => TRUE,
+    '#default_value' => $donation->pledged,
+  );
+  $form['recieved'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Amount Recieved'),
+    '#size' => 10,
+    '#required' => TRUE,
+    '#default_value' => $donation->pledged,
+  );
+
   // Attach the field api fields for the entity.
   field_attach_form('redhen_donation', $donation, $form, $form_state);
 
@@ -1383,6 +1398,12 @@ function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation
 function redhen_donation_edit_form_validate($form, &$form_state) {
   $donation = $form_state['donation'];
 
+  if (!is_numeric($form_state['values']['pledged'])) {
+    form_set_error('pledged', t('Amount pledged must be a number with no currency symbols or commas.'));
+  }
+  if (!is_numeric($form_state['values']['recieved'])) {
+    form_set_error('recieved', t('Amount recieved must be a number with no currency symbols or commas.'));
+  }
   // Notify field widgets to validate their data.
   field_attach_form_validate('redhen_donation', $donation, $form, $form_state);
 }
@@ -1392,6 +1413,9 @@ function redhen_donation_edit_form_validate($form, &$form_state) {
  */
 function redhen_donation_edit_form_submit($form, &$form_state) {
   $donation = $form_state['donation'];
+
+  $donation->pledged = $form_state['values']['pledged'];
+  $donation->recieved = $form_state['values']['recieved'];
 
   // Notify field widgets.
   field_attach_submit('redhen_donation', $donation, $form, $form_state);

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1360,14 +1360,14 @@ function redhen_donation_edit_form($form, &$form_state, RedhenDonation $donation
     '#title' => t('Amount Pledged'),
     '#size' => 10,
     '#required' => TRUE,
-    '#default_value' => number_format($donation->pledged / 100, 2),
+    '#default_value' => number_format($donation->pledged / 100, 2, '.', ''),
   );
   $form['received'] = array(
     '#type' => 'textfield',
     '#title' => t('Amount Received'),
     '#size' => 10,
     '#required' => TRUE,
-    '#default_value' => number_format($donation->received / 100, 2),
+    '#default_value' => number_format($donation->received / 100, 2, '.', ''),
   );
 
   // Attach the field api fields for the entity.

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1293,7 +1293,6 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
 
   $contact_wrapper = entity_metadata_wrapper('redhen_contact', $contact_object);
   $form['redhen_contact'] = array(
-    '#tree' => TRUE,
     '#type' => 'fieldset',
     '#title' => t('Contact Information'),
     '#weight' => -10,
@@ -1325,10 +1324,10 @@ function redhen_donation_add_form_submit($form, &$form_state) {
   // Upsert the redhen contact and include its id in the donation object.
   $contact = $form_state['redhen_contact'];
   $contact->author_uid = $GLOBALS['user']->uid;
-  $contact->first_name = $form_state['values']['redhen_contact']['name']['first_name'];
-  $contact->middle_name = $form_state['values']['redhen_contact']['name']['middle_name'];
-  $contact->last_name = $form_state['values']['redhen_contact']['name']['last_name'];
-  field_attach_submit('redhen_contact', $contact, $form['redhen_contact'], $form_state);
+  $contact->first_name = $form_state['values']['first_name'];
+  $contact->middle_name = $form_state['values']['middle_name'];
+  $contact->last_name = $form_state['values']['last_name'];
+  field_attach_submit('redhen_contact', $contact, $form, $form_state);
   $ret = $contact->upsert();
   $form_state['donation']->contact_id = $form_state['redhen_contact']->contact_id;
 

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1291,8 +1291,8 @@ function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
   );
   // Add all the non-# fields from the redhen contact form.
   $contact_form = redhen_contact_contact_form(array(), $form_state, $contact_object);
-  foreach ($contact_form as $key => $element) {
-    if (substr($key, 0, 1) != '#' && $key != 'actions') {
+  foreach (element_children($contact_form) as $key) {
+    if ($key != 'actions') {
       $form['redhen_contact'][$key] = $contact_form[$key];
     }
   }

--- a/includes/redhen_donation.forms.inc
+++ b/includes/redhen_donation.forms.inc
@@ -1273,15 +1273,8 @@ function redhen_donation_fieldmap_options($entity_type, $entity_bundle = NULL, $
  */
 function redhen_donation_add_form($form, &$form_state, $entity_type, $entity) {
 
-  // TO REFACTOR: Same logic as redhen_donation_donate_page().
   list($entity_id) = entity_extract_ids($entity_type, $entity);
-  $donation_type = redhen_donation_get_entity_donation_type($entity_type, $entity);
-  $donation = entity_get_controller('redhen_donation')->create(array(
-    'entity_type' => $entity_type,
-    'entity_id' => $entity_id,
-    'type' => $donation_type,
-    'author_uid' => $GLOBALS['user']->uid,
-  ));
+  $donation = redhen_donation_initialize_donation($entity_type, $entity, $entity_id, $GLOBALS['user']->uid);
   // Add the donation information edit form.
   $form += redhen_donation_edit_form($form, $form_state, $donation);
 

--- a/includes/redhen_donation.pages.inc
+++ b/includes/redhen_donation.pages.inc
@@ -30,12 +30,7 @@ function redhen_donation_donation_title($entity_type, $entity) {
 function redhen_donation_donate_page($entity_type, $entity) {
   list($entity_id) = entity_extract_ids($entity_type, $entity);
   if (redhen_donation_status($entity_type, $entity_id)) {
-    $donation_type = redhen_donation_get_entity_donation_type($entity_type, $entity);
-    $donation = entity_get_controller('redhen_donation')->create(array(
-      'entity_type' => $entity_type,
-      'entity_id' => $entity_id,
-      'type' => $donation_type,
-    ));
+    $donation = redhen_donation_initialize_donation($entity, $entity_type, $entity_id);
     return drupal_get_form('redhen_donation_form', $donation);
   }
   else {

--- a/includes/redhen_donation.pages.inc
+++ b/includes/redhen_donation.pages.inc
@@ -138,10 +138,10 @@ function redhen_donation_donations_page($entity_type, $entity) {
         $user_col = t('Anonymous');
       }
 
-      $transaction_entity_wrapper = $wrapper->transaction_entity;
-      $transaction_entity = $transaction_entity_wrapper->value();
-      $transaction_entity_type = $wrapper->transaction_entity_type->value();
-      if ($transaction_entity) {
+      if ($donation->transaction_entity_id) {
+        $transaction_entity_wrapper = $wrapper->transaction_entity;
+        $transaction_entity = $transaction_entity_wrapper->value();
+        $transaction_entity_type = $wrapper->transaction_entity_type->value();
         $transaction_entity_uri = entity_uri($transaction_entity_type, $transaction_entity);
         $transaction_entity_label = entity_label($transaction_entity_type, $transaction_entity);
         if (isset($transaction_entity_uri['path'])) {

--- a/lib/redhen_donation.entity.inc
+++ b/lib/redhen_donation.entity.inc
@@ -142,94 +142,96 @@ class RedhenDonation extends Entity {
       '#classes' => 'field field-label-inline clearfix',
     );
 
-    $content['transaction'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Transaction(s)'),
-      '#collapsible' => FALSE,
-      '#collapsed' => FALSE,
-    );
+    if (isset($this->transaction_entity_type) && isset($this->transaction_entity_id)) {
+      $content['transaction'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Transaction(s)'),
+        '#collapsible' => FALSE,
+        '#collapsed' => FALSE,
+      );
 
-    $rows = array();
-    $header = array(t('Order ID'), t('Amount'), t('Order Date'), t('Status'));
-    $order_status = commerce_order_statuses();
-    switch ($this->transaction_entity_type) {
-      case 'commerce_recurring':
-        $transaction_entity = $transaction_entity_wrapper->value();
-        $transaction_entity_uri = entity_uri($this->transaction_entity_type, $transaction_entity);
-        foreach ($transaction_entity_wrapper->commerce_recurring_order->value() as $order) {
-          $rows[] = $this->transactionRow($order, $order_status);
-        }
-        $product_wrapper = $transaction_entity_wrapper->commerce_recurring_ref_product;
-        $transactions = array(
-          'recurring_donation' => array(
-            '#type' => 'fieldset',
-            '#title' => l(
-              t('Recurring Donation @rec_id',
-                array(
-                  '@rec_id' => $transaction_entity->id,
-                )
+      $rows = array();
+      $header = array(t('Order ID'), t('Amount'), t('Order Date'), t('Status'));
+      $order_status = commerce_order_statuses();
+      switch ($this->transaction_entity_type) {
+        case 'commerce_recurring':
+          $transaction_entity = $transaction_entity_wrapper->value();
+          $transaction_entity_uri = entity_uri($this->transaction_entity_type, $transaction_entity);
+          foreach ($transaction_entity_wrapper->commerce_recurring_order->value() as $order) {
+            $rows[] = $this->transactionRow($order, $order_status);
+          }
+          $product_wrapper = $transaction_entity_wrapper->commerce_recurring_ref_product;
+          $transactions = array(
+            'recurring_donation' => array(
+              '#type' => 'fieldset',
+              '#title' => l(
+                t('Recurring Donation @rec_id',
+                  array(
+                    '@rec_id' => $transaction_entity->id,
+                  )
+                ),
+                $transaction_entity_uri['path']
               ),
-              $transaction_entity_uri['path']
-            ),
-            'amount' => array(
-              '#type' => 'item',
-              '#title' => t('Amount'),
-              '#markup' => commerce_currency_format(
-                $transaction_entity_wrapper->commerce_recurring_fixed_price->amount->value(),
-                $transaction_entity_wrapper->commerce_recurring_fixed_price->currency_code->value()
+              'amount' => array(
+                '#type' => 'item',
+                '#title' => t('Amount'),
+                '#markup' => commerce_currency_format(
+                  $transaction_entity_wrapper->commerce_recurring_fixed_price->amount->value(),
+                  $transaction_entity_wrapper->commerce_recurring_fixed_price->currency_code->value()
+                ),
+              ),
+              'frequency' => array(
+                '#type' => 'item',
+                '#title' => t('Frequency'),
+                '#markup' => redhen_donation_product_description($product_wrapper),
+              ),
+              'start_date' => array(
+                '#type' => 'item',
+                '#title' => t('Start Date'),
+                '#markup' => date('m-d-Y H:m',
+                  $transaction_entity_wrapper->start_date->value()),
+              ),
+              'end_date' => array(
+                '#type' => 'item',
+                '#title' => t('End Date'),
+                '#markup' => $transaction_entity_wrapper->end_date->value() == 0 ? t('None') : date('m-d-Y H:m', $transaction_entity_wrapper->end_date->value()),
+              ),
+              'due_date' => array(
+                '#type' => 'item',
+                '#title' => t('Due Date'),
+                '#markup' => date('m-d-Y H:m', $transaction_entity_wrapper->due_date->value()),
+              ),
+              'status' => array(
+                '#type' => 'item',
+                '#title' => t('Status'),
+                '#markup' => $transaction_entity_wrapper->status->value() ? t('Enabled') : t('Disabled'),
               ),
             ),
-            'frequency' => array(
-              '#type' => 'item',
-              '#title' => t('Frequency'),
-              '#markup' => redhen_donation_product_description($product_wrapper),
+            'orders' => array(
+              '#theme' => 'table',
+              '#header' => $header,
+              '#rows' => $rows,
             ),
-            'start_date' => array(
-              '#type' => 'item',
-              '#title' => t('Start Date'),
-              '#markup' => date('m-d-Y H:m',
-                $transaction_entity_wrapper->start_date->value()),
-            ),
-            'end_date' => array(
-              '#type' => 'item',
-              '#title' => t('End Date'),
-              '#markup' => $transaction_entity_wrapper->end_date->value() == 0 ? t('None') : date('m-d-Y H:m', $transaction_entity_wrapper->end_date->value()),
-            ),
-            'due_date' => array(
-              '#type' => 'item',
-              '#title' => t('Due Date'),
-              '#markup' => date('m-d-Y H:m', $transaction_entity_wrapper->due_date->value()),
-            ),
-            'status' => array(
-              '#type' => 'item',
-              '#title' => t('Status'),
-              '#markup' => $transaction_entity_wrapper->status->value() ? t('Enabled') : t('Disabled'),
-            ),
-          ),
-          'orders' => array(
-            '#theme' => 'table',
-            '#header' => $header,
-            '#rows' => $rows,
-          ),
-        );
-        break;
+          );
+          break;
 
-      default:
-        $transaction_entity = $transaction_entity_wrapper->value();
-        $rows[] = $this->transactionRow($transaction_entity, $order_status);
-        $transactions = array(
-          'var' => array(
-            '#markup' => t('One Time Donation'),
-          ),
-          'stuff' => array(
-            '#theme' => 'table',
-            '#header' => $header,
-            '#rows' => $rows,
-          ),
-        );
-        break;
+        default:
+          $transaction_entity = $transaction_entity_wrapper->value();
+          $rows[] = $this->transactionRow($transaction_entity, $order_status);
+          $transactions = array(
+            'var' => array(
+              '#markup' => t('One Time Donation'),
+            ),
+            'stuff' => array(
+              '#theme' => 'table',
+              '#header' => $header,
+              '#rows' => $rows,
+            ),
+          );
+          break;
+      }
+      $content['transaction']['list'] = $transactions;
     }
-    $content['transaction']['list'] = $transactions;
 
     return entity_get_controller($this->entityType)->buildContent($this, $view_mode, $langcode, $content);
   }

--- a/redhen_donation.install
+++ b/redhen_donation.install
@@ -53,27 +53,23 @@ function redhen_donation_schema() {
       'order_id' => array(
         'description' => 'The identifier of the Order this donation is associated with.',
         'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
+        'not null' => FALSE,
       ),
       'line_item_id' => array(
         'description' => 'The identifier of the Commerce Line Item this donation is associated with.',
         'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
+        'not null' => FALSE,
       ),
       'transaction_entity_type' => array(
         'description' => 'The entity type of the transaction (order or recurring) associated with this donation.',
         'type' => 'varchar',
         'length' => 32,
-        'not null' => TRUE,
-        'default' => 0,
+        'not null' => FALSE,
       ),
       'transaction_entity_id' => array(
         'description' => 'The entity id of the transaction associated with this donation.',
         'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
+        'not null' => FALSE,
       ),
       'pledged' => array(
         'description' => 'The amount pledged for this donation.',
@@ -105,8 +101,6 @@ function redhen_donation_schema() {
       'donation_author_uid' => array('author_uid'),
       'donation_contact_id' => array('contact_id'),
       'donation_type' => array(array('type', 4)),
-    ),
-    'unique keys' => array(
       'transaction' => array('transaction_entity_type', 'transaction_entity_id'),
     ),
     'foreign keys' => array(
@@ -347,4 +341,33 @@ function redhen_donation_update_7003() {
     }
     $donation->save();
   }
+}
+
+/**
+ * Allow references to commerce orders to be null for redhen_donations.
+ */
+function redhen_donation_update_7004() {
+  db_drop_unique_key('redhen_donation', 'transaction');
+  db_change_field('redhen_donation', 'order_id', 'order_id', array(
+    'description' => 'The identifier of the Order this donation is associated with.',
+    'type' => 'int',
+    'not null' => FALSE,
+  ));
+  db_change_field('redhen_donation', 'line_item_id', 'line_item_id', array(
+    'description' => 'The identifier of the Commerce Line Item this donation is associated with.',
+    'type' => 'int',
+    'not null' => FALSE,
+  ));
+  db_change_field('redhen_donation', 'transaction_entity_type', 'transaction_entity_type', array(
+    'description' => 'The entity type of the transaction (order or recurring) associated with this donation.',
+    'type' => 'varchar',
+    'length' => 32,
+    'not null' => FALSE,
+  ));
+  db_change_field('redhen_donation', 'transaction_entity_id', 'transaction_entity_id', array(
+    'description' => 'The entity id of the transaction associated with this donation.',
+    'type' => 'int',
+    'not null' => FALSE,
+  ));
+  db_add_index('redhen_donation', 'transaction', array('transaction_entity_type', 'transaction_entity_id'));
 }

--- a/redhen_donation.module
+++ b/redhen_donation.module
@@ -1309,3 +1309,23 @@ function redhen_donation_commerce_recurring_uri($recurring_entity) {
   }
   return $uri;
 }
+
+/**
+ * Helper function to build a new Donation entity for use in forms.
+ */
+function redhen_donation_initialize_donation($entity, $entity_type, $entity_id = NULL, $author_id = NULL) {
+  if (!$entity_id) {
+    list($entity_id) = entity_extract_ids($entity_type, $entity);
+  }
+  $donation_type = redhen_donation_get_entity_donation_type($entity_type, $entity);
+  $properties = array(
+    'entity_type' => $entity_type,
+    'entity_id' => $entity_id,
+    'type' => $donation_type,
+  );
+  if ($author_id) {
+    $properties['author_uid'] = $author_id;
+  }
+  $donation = entity_get_controller('redhen_donation')->create($properties);
+  return $donation;
+}

--- a/redhen_donation.module
+++ b/redhen_donation.module
@@ -938,8 +938,10 @@ function redhen_donation_property_user_set(RedhenDonation $donation, $name, $val
  * @see RedhenDonationMetadataController::entityPropertyInfo()
  */
 function redhen_donation_property_transaction_entity_get(RedhenDonation $donation, array $options, $property_name, $entity_type) {
-  $entity = entity_load_single($donation->transaction_entity_type, $donation->transaction_entity_id);
-  return $entity ? entity_metadata_wrapper($donation->transaction_entity_type, $entity) : NULL;
+  if (isset($donation->transaction_entity_type) && isset($donation->transaction_entity_id)) {
+    $entity = entity_load_single($donation->transaction_entity_type, $donation->transaction_entity_id);
+    return $entity ? entity_metadata_wrapper($donation->transaction_entity_type, $entity) : NULL;
+  }
 }
 
 /**
@@ -948,8 +950,10 @@ function redhen_donation_property_transaction_entity_get(RedhenDonation $donatio
  * @see RedhenDonationMetadataController::entityPropertyInfo()
  */
 function redhen_donation_property_order_get(RedhenDonation $donation, array $options, $property_name, $entity_type) {
-  $order = commerce_order_load($donation->order_id);
-  return entity_metadata_wrapper('commerce_order', $order);
+  if (isset($donation->order_id)) {
+    $order = commerce_order_load($donation->order_id);
+    return entity_metadata_wrapper('commerce_order', $order);
+  }
 }
 
 /**
@@ -973,8 +977,10 @@ function redhen_donation_property_redhen_contact_get(RedhenDonation $donation, a
  * @see RedhenDonationMetadataController::entityPropertyInfo()
  */
 function redhen_donation_property_line_item_get(RedhenDonation $donation, array $options, $property_name, $entity_type) {
-  $line_item = commerce_line_item_load($donation->line_item_id);
-  return entity_metadata_wrapper('commerce_line_item', $line_item);
+  if (isset($donation->line_item_id)) {
+    $line_item = commerce_line_item_load($donation->line_item_id);
+    return entity_metadata_wrapper('commerce_line_item', $line_item);
+  }
 }
 
 /**

--- a/redhen_donation.module
+++ b/redhen_donation.module
@@ -1033,11 +1033,8 @@ function redhen_donation_property_pledged_get(RedhenDonation $donation, array $o
  */
 function redhen_donation_get_formatted_amount(RedhenDonation $donation, $amount_type) {
   $wrapper = entity_metadata_wrapper('redhen_donation', $donation);
-  if($donation->order_id) {
-    $currency_code = $wrapper->order->commerce_order_total->currency_code->value();
-    return commerce_currency_format($donation->$amount_type, $currency_code);
-  }
-  return number_format($donation->$amount_type, 2);
+  $currency_code = $donation->order_id ? $wrapper->order->commerce_order_total->currency_code->value() : commerce_default_currency();
+  return commerce_currency_format($donation->$amount_type, $currency_code);
 }
 
 /**

--- a/redhen_donation.module
+++ b/redhen_donation.module
@@ -185,7 +185,16 @@ function redhen_donation_menu() {
     'file' => 'includes/redhen_donation.pages.inc',
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
-
+  $items['redhen/donation/%redhen_donation/edit'] = array(
+    'title' => 'Edit',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('redhen_donation_edit_form', 2),
+    'access callback' => 'entity_access',
+    'access arguments' => array('edit', 'redhen_donation', 2),
+    'file' => 'includes/redhen_donation.forms.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 1,
+  );
   // Entity local tasks.
   foreach (redhen_donation_get_donation_instances() as $instance) {
     $type = $instance['entity_type'];

--- a/redhen_donation.module
+++ b/redhen_donation.module
@@ -260,6 +260,17 @@ function redhen_donation_menu() {
         'type' => MENU_LOCAL_TASK,
         'file' => 'includes/redhen_donation.pages.inc',
       );
+      $items[$menu_root . '/donations/add'] = array(
+        'load arguments' => array($type),
+        'title' => 'Add Donation',
+        'page callback' => 'drupal_get_form',
+        'page arguments' => array('redhen_donation_add_form', $type, $position),
+        'access callback' => 'entity_access',
+        'access arguments' => array('create', 'redhen_donation'),
+        'type' => MENU_LOCAL_TASK,
+        'weight' => 8,
+        'file' => 'includes/redhen_donation.forms.inc',
+      );
     }
   }
 
@@ -970,6 +981,11 @@ function redhen_donation_property_line_item_get(RedhenDonation $donation, array 
  * Getter callback for donation status.
  */
 function redhen_donation_property_status_get(RedhenDonation $donation, array $options, $property_name, $entity_type) {
+
+  // Check that there is a transaction before trying to access it.
+  if (empty($donation->transaction_entity_id)) {
+    return "n/a";
+  }
   $wrapper = entity_metadata_wrapper('redhen_donation', $donation);
   $transaction_entity = $wrapper->transaction_entity->value();
   if (!$transaction_entity) {
@@ -1011,8 +1027,11 @@ function redhen_donation_property_pledged_get(RedhenDonation $donation, array $o
  */
 function redhen_donation_get_formatted_amount(RedhenDonation $donation, $amount_type) {
   $wrapper = entity_metadata_wrapper('redhen_donation', $donation);
-  $currency_code = $wrapper->order->commerce_order_total->currency_code->value();
-  return commerce_currency_format($donation->$amount_type, $currency_code);
+  if($donation->order_id) {
+    $currency_code = $wrapper->order->commerce_order_total->currency_code->value();
+    return commerce_currency_format($donation->$amount_type, $currency_code);
+  }
+  return number_format($donation->$amount_type, 2);
 }
 
 /**


### PR DESCRIPTION
CAFB needs the ability to edit donation that have come in, when people have made mistakes when filling out the donation form. They also need a way to add new donations that have been received in the form of checks or cash to the campaigns, so that they are reflected in the totals. These seems like use cases that other orgs using redhen_donation would encounter, so we should probably add this feature to the next version of redhen_donation.
